### PR TITLE
Added necessary Perl modules for clean Linux installs in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ See the GitHub wiki page for screenshots.
 Reqirements: Linux running cgminer or clone. Built and tested on litecoin-bamt 1.2. 
 Packages req: Perl5 + libjson-perl, libyaml-perl, rrdtool. 
 
-NOTE! Installation does not check dependencies yet. This should work out of the box on BAMT, but will need Perl modules libjson-perl and libyaml-perl on clean Linux installs. 
+NOTE! Installation does not check dependencies yet. This should work out of the box on BAMT, but will need the following Perl modules on clean Linux installs : 
+
+* libjson-perl
+* libyaml-perl 
+* librrds-perl
 
 ------
 


### PR DESCRIPTION
I happens that on Ubuntu one will need `librrds-perl` to make graphs work.
