### PR TITLE
Added libemail-sender-transport-smtp-tls-perl package to Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ and additionally for email notifications..
 * libemail-simple-perl
 * libemail-sender-perl
 * libtry-tiny-perl
+* libemail-sender-transport-smtp-tls-perl (for TLS)
 
 ------
 


### PR DESCRIPTION
It is necessary for e-mail notifications while using TLS.
